### PR TITLE
give debian-transmission group rw perms on settings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
     dest: /etc/transmission-daemon/settings.json
     owner: debian-transmission
     group: debian-transmission
-    mode: 0600
+    mode: 0660
   notify: "transmission-daemon | reload settings"
 
 - name: "transmission-daemon | Create required directories"


### PR DESCRIPTION
Ubuntu package installs settings.json file as 0660.  Makes sense to me.  Let me know if you agree.