### PR TITLE
#13 Add Prometheus exporter support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,3 +70,18 @@ transmission_upload_limit: 100
 transmission_upload_limit_enabled: 0
 transmission_upload_slots_per_torrent: 14
 transmission_utp_enabled: true
+
+## Transmission Exporter
+transmission_exporter_install: false
+transmission_exporter_version: 0.3.0
+transmission_exporter_user: transmission_exporter
+transmission_exporter_group: transmission_exporter
+transmission_exporter_tmp_path: "/tmp/transmission-exporter-{{ transmission_exporter_version }}"
+transmission_exporter_install_path: "/opt/transmission-exporter"
+transmission_exporter_bin_path: "/usr/bin/transmission-exporter"
+
+### Transmission exporter service
+transmission_exporter_private_tmp: true
+transmission_exporter_max_files: 32768
+transmission_exporter_documentation_link: "https://github.com/metalmatze/transmission-exporter"
+transmission_exporter_log_output: "{% if transmission_exporter_log_file is defined %} file:{{ transmission_exporter_log_file }} {% else %} journal {% endif %}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,7 +76,7 @@ transmission_exporter_install: false
 transmission_exporter_version: 0.3.0
 transmission_exporter_user: transmission_exporter
 transmission_exporter_group: transmission_exporter
-transmission_exporter_tmp_path: "/tmp/transmission-exporter-{{ transmission_exporter_version }}"
+transmission_exporter_tmp_path: "/tmp
 transmission_exporter_install_path: "/opt/transmission-exporter"
 transmission_exporter_bin_path: "/usr/bin/transmission-exporter"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,6 +82,8 @@ transmission_exporter_bin_path: "/usr/bin/transmission-exporter"
 
 ### Transmission exporter service
 transmission_exporter_private_tmp: true
+transmission_exporter_state: started
+transmission_exporter_enabled: true
 transmission_exporter_max_files: 32768
 transmission_exporter_documentation_link: "https://github.com/metalmatze/transmission-exporter"
 transmission_exporter_log_output: "{% if transmission_exporter_log_file is defined %} file:{{ transmission_exporter_log_file }} {% else %} journal {% endif %}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,7 +76,7 @@ transmission_exporter_install: false
 transmission_exporter_version: 0.3.0
 transmission_exporter_user: transmission_exporter
 transmission_exporter_group: transmission_exporter
-transmission_exporter_tmp_path: "/tmp
+transmission_exporter_tmp_path: "/tmp"
 transmission_exporter_install_path: "/opt/transmission-exporter"
 transmission_exporter_bin_path: "/usr/bin/transmission-exporter"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,8 @@
   service:
     name: transmission-daemon
     state: reloaded
+
+- name: "transmission_exporter | reload service"
+  service:
+    name: transmission_exporter
+    state: reloaded

--- a/tasks/exporter.yml
+++ b/tasks/exporter.yml
@@ -27,14 +27,11 @@
 
 - name: "transmission-exporter | Ensure install paths"
   file:
-    dest: "{{ item }}"
+    dest: "{{ transmission_exporter_install_path }}"
     owner: "{{ transmission_exporter_user }}"
     group: "{{ transmission_exporter_group }}"
     state: directory
   when: transmission_exporter_check is failed
-  with_items:
-    - "{{ transmission_exporter_install_path }}"
-    - "{{ transmission_exporter_tmp_path }}"
 
 - name: "transmission-exporter | Download sources"
   get_url:
@@ -52,13 +49,13 @@
 
 - name: "transmission-exporter | Build from sources"
   make:
-    chdir: "{{ transmission_exporter_tmp_path }}"
+    chdir: "{{ transmission_exporter_tmp_path }}/transmission-exporter-{{ transmission_exporter_version }}"
     target: build
   when: transmission_exporter_check is failed
 
 - name: "transmission-exporter | Copy binary"
   copy:
-    src: "{{ transmission_exporter_tmp_path }}/transmission-exporter"
+    src: "{{ transmission_exporter_tmp_path }}/transmission-exporter-{{ transmission_exporter_version }}/transmission-exporter"
     dest: "{{ transmission_exporter_install_path }}/transmission-exporter"
     owner: "{{ transmission_exporter_user }}"
     group: "{{ transmission_exporter_group }}"

--- a/tasks/exporter.yml
+++ b/tasks/exporter.yml
@@ -27,11 +27,14 @@
 
 - name: "transmission-exporter | Ensure install paths"
   file:
-    dest: "{{ transmission_exporter_install_path }}"
+    dest: "{{ item }}"
     owner: "{{ transmission_exporter_user }}"
     group: "{{ transmission_exporter_group }}"
     state: directory
   when: transmission_exporter_check is failed
+  with_items:
+    - "{{ transmission_exporter_install_path }}"
+    - "{{ transmission_exporter_tmp_path }}"
 
 - name: "transmission-exporter | Download sources"
   get_url:

--- a/tasks/exporter.yml
+++ b/tasks/exporter.yml
@@ -1,0 +1,88 @@
+---
+
+- name: "transmission-exporter | Download dependencies"
+  package:
+    name: golang
+    state: present
+
+- name: "transmission-exporter | Ensure group"
+  group:
+    name: "{{ transmission_exporter_group }}"
+    system: true
+    state: present
+
+- name: "transmission-exporter | Ensure user"
+  user:
+    name: "{{ transmission_exporter_user }}"
+    group: "{{ transmission_exporter_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    createhome: false
+
+- name: "transmission-exporter | Ensure user"
+  command: "transmission-exporter -h"
+  register: transmission_exporter_check
+  changed_when: false
+  ignore_errors: true
+
+- name: "transmission-exporter | Ensure install paths"
+  file:
+    dest: "{{ transmission_exporter_install_path }}"
+    owner: "{{ transmission_exporter_user }}"
+    group: "{{ transmission_exporter_group }}"
+    state: directory
+  when: transmission_exporter_check is failed
+
+- name: "transmission-exporter | Download sources"
+  get_url:
+    url: "{{ transmission_exporter_download_url }}"
+    dest: /tmp
+  when: transmission_exporter_check is failed
+
+
+- name: "transmission-exporter | Unarchive download"
+  unarchive:
+    src: "/tmp/transmission-exporter-{{ transmission_exporter_version }}.tar.gz"
+    dest: "{{ transmission_exporter_tmp_path }}"
+    remote_src: yes
+  when: transmission_exporter_check is failed
+
+- name: "transmission-exporter | Build from sources"
+  make:
+    chdir: "{{ transmission_exporter_tmp_path }}"
+    target: build
+  when: transmission_exporter_check is failed
+
+- name: "transmission-exporter | Copy binary"
+  copy:
+    src: "{{ transmission_exporter_tmp_path }}/transmission-exporter"
+    dest: "{{ transmission_exporter_install_path }}/transmission-exporter"
+    owner: "{{ transmission_exporter_user }}"
+    group: "{{ transmission_exporter_group }}"
+    remote_src: true
+    mode: 0755
+  notify: "transmission_exporter | restart service"
+  when: transmission_exporter_check is failed
+
+- name: "transmission-exporter | Link binary"
+  file:
+    src: "{{ transmission_exporter_install_path }}/transmission-exporter"
+    dest: "{{ transmission_exporter_bin_path }}"
+    state: link
+  notify: "transmission_exporter | restart service"
+  when: transmission_exporter_check is failed
+
+- name: "transmission-exporter | Copy service file"
+  template:
+    src: transmission_exporter.service.j2
+    dest: /etc/systemd/system/transmission_exporter.service
+    mode: 0644
+  notify: "transmission_exporter | restart service"
+
+- name: "transmission-exporter | Configure service"
+  systemd:
+    name: transmission_exporter
+    state: "{{ transmission_exporter_state }}"
+    enabled: "{{ transmission_exporter_enabled }}"
+    daemon_reload: true
+  notify: "transmission_exporter | restart service"

--- a/tasks/exporter.yml
+++ b/tasks/exporter.yml
@@ -2,7 +2,7 @@
 
 - name: "transmission-exporter | Download dependencies"
   package:
-    name: golang
+    name: [golang, git]
     state: present
 
 - name: "transmission-exporter | Ensure group"
@@ -61,7 +61,7 @@
     group: "{{ transmission_exporter_group }}"
     remote_src: true
     mode: 0755
-  notify: "transmission_exporter | restart service"
+  notify: "transmission_exporter | reload service"
   when: transmission_exporter_check is failed
 
 - name: "transmission-exporter | Link binary"
@@ -69,7 +69,7 @@
     src: "{{ transmission_exporter_install_path }}/transmission-exporter"
     dest: "{{ transmission_exporter_bin_path }}"
     state: link
-  notify: "transmission_exporter | restart service"
+  notify: "transmission_exporter | reload service"
   when: transmission_exporter_check is failed
 
 - name: "transmission-exporter | Copy service file"
@@ -77,7 +77,7 @@
     src: transmission_exporter.service.j2
     dest: /etc/systemd/system/transmission_exporter.service
     mode: 0644
-  notify: "transmission_exporter | restart service"
+  notify: "transmission_exporter | reload service"
 
 - name: "transmission-exporter | Configure service"
   systemd:
@@ -85,4 +85,4 @@
     state: "{{ transmission_exporter_state }}"
     enabled: "{{ transmission_exporter_enabled }}"
     daemon_reload: true
-  notify: "transmission_exporter | restart service"
+  notify: "transmission_exporter | reload service"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,3 +29,9 @@
   service:
     name: transmission-daemon
     state: started
+
+- name: "transmission-exporter | Include tasks"
+  include_tasks: exporter.yml
+  when: transmission_exporter_install
+  tags:
+    - transmission_exporter

--- a/templates/transmission_exporter.service.j2
+++ b/templates/transmission_exporter.service.j2
@@ -12,7 +12,7 @@ Group={{ transmission_exporter_group }}
 RuntimeDirectory=transmission_exporter
 LimitNOFILE={{ transmission_exporter_max_files }}
 
-ExecStart=
+ExecStart={{ transmission_exporter_bin_path }}
 
 StandardOutput={{ transmission_exporter_log_output }}
 StandardError={{ transmission_exporter_log_output }}

--- a/templates/transmission_exporter.service.j2
+++ b/templates/transmission_exporter.service.j2
@@ -1,0 +1,24 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=transmission_exporter
+Documentation={{ transmission_exporter_documentation_link }}
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+PrivateTmp={{ transmission_exporter_private_tmp }}
+User={{ transmission_exporter_user }}
+Group={{ transmission_exporter_group }}
+RuntimeDirectory=transmission_exporter
+LimitNOFILE={{ transmission_exporter_max_files }}
+
+ExecStart=
+
+StandardOutput={{ transmission_exporter_log_output }}
+StandardError={{ transmission_exporter_log_output }}
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,3 +14,5 @@ transmission_group:
   Ubuntu: debian-transmission
   Fedora: transmission
   RedHat: transmission
+
+transmission_exporter_download_url: "https://github.com/metalmatze/transmission-exporter/archive/refs/tags/{{ transmission_exporter_version }}.tar.gz"


### PR DESCRIPTION
As already mentioned in #13, add Prometheus exporter installation support, set by default to false.

Ended up being a little bigger than I expected because it has to be build from source (metalmatze/transmission-exporter does not offer pre-compiled binaries)